### PR TITLE
Add `display` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The cookiecutter will prompt you with the following questions and generate a pro
   
 * `author_name`: Your full name. This will be used in the generated Python and npm packages.
 * `author_email`: Your email address. This will be used in the generated Python and npm packages.
-* `mime_type`: A valid mime type (e.g. `application/json`, `application/table-schema+json`). This will be used to render output data of this mime type with your extension.
+* `mime_type`: A valid mime type (e.g. `application/json`, `application/table-schema+json`, `application/vnd.plotly.v1+json`). This will be used to render output data of this mime type with your extension.
 * `mime_short_name`: A display name (no spaces) for your mime type (e.g. `JSON`, `JSONTable`). This will be used in the generated Python and npm packages, README, and class names.
 * `file_extension`: **_OPTIONAL_** A valid file extension (e.g. `json`, `xml`). This will be used to open files of this type with your extension.
 * `extension_name`: Your JupyterLab and Jupyter Notebook extension name (e.g. `jupyerlab_json`, `jupyerlab_table`).
@@ -46,6 +46,7 @@ In most cases, you will only need to edit the `OutputWidget._render` method in `
 * `extension_name`
   * `extension_name`: The Python package
     * `static`: Compiled Javascript for both extensions
+    * `__init.py__`: Exports paths and metadata of lab and notebook extensions and exports an optional `display` method that can be imported into a notebook and used to easily display data using this renderer
   * `labextension`: The JupyterLab extension
     * `src`
       * `doc.js`: Widget/widget factory used for opening files with an extension of `file_extension` defined in prompts

--- a/{{cookiecutter.extension_name}}/.gitignore
+++ b/{{cookiecutter.extension_name}}/.gitignore
@@ -1,5 +1,6 @@
 labextension/lib/
 nbextension/lib/
+nbextension/embed/
 */node_modules/
 npm-debug.log
 *.egg-info/

--- a/{{cookiecutter.extension_name}}/MANIFEST.in
+++ b/{{cookiecutter.extension_name}}/MANIFEST.in
@@ -1,3 +1,5 @@
 graft {{ cookiecutter.extension_name }}/static
-graft src
-include package.json
+graft labextension/src
+graft nbextension/src
+include labextension/package.json
+include nbextension/package.json

--- a/{{cookiecutter.extension_name}}/README.md
+++ b/{{cookiecutter.extension_name}}/README.md
@@ -13,15 +13,18 @@ A JupyterLab and Jupyter Notebook extension for rendering {{cookiecutter.mime_sh
 To render {{cookiecutter.mime_short_name}} output in IPython:
 
 ```python
-from IPython.display import JSON
-JSON({
+from {{ cookiecutter.extension_name }} import {{ cookiecutter.mime_short_name }}
+
+data = {
     'string': 'string',
     'array': [1, 2, 3],
     'bool': True,
     'object': {
         'foo': 'bar'
     }
-})
+}
+
+{{ cookiecutter.mime_short_name }}(data)
 ```
 
 To render a .{{cookiecutter.file_extension}} file as a tree, simply open it:

--- a/{{cookiecutter.extension_name}}/nbextension/src/renderer.js
+++ b/{{cookiecutter.extension_name}}/nbextension/src/renderer.js
@@ -16,7 +16,7 @@ function render(data, node) {
 export function register_renderer($) {
   // Get an instance of the OutputArea object from the first CodeCellebook_
   const OutputArea = $('#notebook-container').find('.code_cell').eq(0).data('cell').output_area;
-  // A function to render output of 'application/vnd.plotly.v1+json' mime type
+  // A function to render output of '{{cookiecutter.mime_type}}' mime type
   const append_mime = function(json, md, element) {
     const type = MIME_TYPE;
     const toinsert = this.create_output_subarea(md, 'output_{{cookiecutter.mime_short_name}} rendered_html', type);
@@ -40,13 +40,13 @@ export function register_renderer($) {
 }
 
 //
-// Re-render cells with output data of 'application/vnd.plotly.v1+json' mime type
+// Re-render cells with output data of '{{cookiecutter.mime_type}}' mime type
 // 
 export function render_cells($) {
   // Get all cells in notebook
   $('#notebook-container').find('.cell').toArray().forEach(item => {
     const CodeCell = $(item).data('cell');
-    // If a cell has output data of 'application/vnd.plotly.v1+json' mime type
+    // If a cell has output data of '{{cookiecutter.mime_type}}' mime type
     if (CodeCell.output_area && CodeCell.output_area.outputs.find(output => output.data[MIME_TYPE])) {
       // Re-render the cell by executing it
       CodeCell.notebook.render_cell_output(CodeCell);

--- a/{{cookiecutter.extension_name}}/setup.py
+++ b/{{cookiecutter.extension_name}}/setup.py
@@ -29,7 +29,8 @@ setup_args = dict(
     keywords             = ['jupyter', 'jupyterlab', 'labextension', 'notebook', 'nbextension'],
     include_package_data = True,
     install_requires = [
-        'jupyterlab>=0.8.0',
+        'jupyterlab>=0.11.0',
+        'ipython>=1.0.0'
     ]
 )
 

--- a/{{cookiecutter.extension_name}}/{{cookiecutter.extension_name}}/README.md
+++ b/{{cookiecutter.extension_name}}/{{cookiecutter.extension_name}}/README.md
@@ -1,0 +1,8 @@
+# {{ cookiecutter.extension_name }}
+
+Single Python package for lab and notebook extensions
+
+## Structure
+
+* `static`: Built Javascript from `../labextension/` and `../nbextension/`
+* `__init__.py`: Exports paths for lab and notebook extensions

--- a/{{cookiecutter.extension_name}}/{{cookiecutter.extension_name}}/__init__.py
+++ b/{{cookiecutter.extension_name}}/{{cookiecutter.extension_name}}/__init__.py
@@ -1,3 +1,6 @@
+from IPython.display import display
+
+
 # Running `npm run build` will create static resources in the static
 # directory of this Python package (and create that directory if necessary).
 
@@ -15,3 +18,16 @@ def _jupyter_nbextension_paths():
         'dest': '{{ cookiecutter.extension_name }}',
         'require': '{{ cookiecutter.extension_name }}/extension'
     }]
+
+
+# A display function that can be used within a notebook. E.g.:
+#   from {{ cookiecutter.extension_name }} import {{ cookiecutter.mime_short_name }}
+#   {{ cookiecutter.mime_short_name }}(data)
+
+def {{ cookiecutter.mime_short_name }}(data):
+    bundle = {
+        '{{ cookiecutter.mime_type }}': data,
+        'application/json': data,
+        'text/plain': '<{{ cookiecutter.extension_name }}.{{ cookiecutter.mime_short_name }} object>'
+    }
+    display(bundle, raw=True)


### PR DESCRIPTION
Provides a `display` method that can be imported into a notebook:

```py
from jupyterlab_plotly import Plotly

data = [
  {'x': [1999, 2000, 2001, 2002], 'y': [10, 15, 13, 17], 'type': 'scatter'},
  {'x': [1999, 2000, 2001, 2002], 'y': [16, 5, 11, 9], 'type': 'scatter'}
]

layout = {
  'title': 'Sales Growth',
  'xaxis': { 'title': 'Year', 'showgrid': False, 'zeroline': False },
  'yaxis': { 'title': 'Percent', 'showline': False }
}

Plotly(data, layout)
```