### PR TITLE
Add `display` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ The cookiecutter will prompt you with the following questions and generate a pro
   
 * `author_name`: Your full name. This will be used in the generated Python and npm packages.
 * `author_email`: Your email address. This will be used in the generated Python and npm packages.
-* `mime_type`: A valid mime type (e.g. `application/json`, `application/table-schema+json`, `application/vnd.plotly.v1+json`). This will be used to render output data of this mime type with your extension.
-* `mime_short_name`: A display name (no spaces) for your mime type (e.g. `JSON`, `JSONTable`). This will be used in the generated Python and npm packages, README, and class names.
+* `mime_type`: A valid mime type (e.g. `application/json`, `application/geo+json`, `application/vnd.plotly.v1+json`). This will be used to render output data of this mime type with your extension.
+* `mime_short_name`: A display name (no spaces) for your mime type (e.g. `JSON`, `GeoJSON`). This will be used in the generated Python and npm packages, README, and class names.
 * `file_extension`: **_OPTIONAL_** A valid file extension (e.g. `json`, `xml`). This will be used to open files of this type with your extension.
-* `extension_name`: Your JupyterLab and Jupyter Notebook extension name (e.g. `jupyerlab_json`, `jupyerlab_table`).
+* `extension_name`: Your JupyterLab and Jupyter Notebook extension name (e.g. `jupyerlab_json`, `jupyerlab_geojson`).
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The cookiecutter will prompt you with the following questions and generate a pro
   
 * `author_name`: Your full name. This will be used in the generated Python and npm packages.
 * `author_email`: Your email address. This will be used in the generated Python and npm packages.
-* `mime_type`: A valid mime type (e.g. `application/json`, `application/table-schema+json`). This will be used to render output data of this mime type with your extension.
+* `mime_type`: A valid mime type (e.g. `application/json`, `application/table-schema+json`, `application/vnd.plotly.v1+json`). This will be used to render output data of this mime type with your extension.
 * `mime_short_name`: A display name (no spaces) for your mime type (e.g. `JSON`, `JSONTable`). This will be used in the generated Python and npm packages, README, and class names.
 * `file_extension`: **_OPTIONAL_** A valid file extension (e.g. `json`, `xml`). This will be used to open files of this type with your extension.
 * `extension_name`: Your JupyterLab and Jupyter Notebook extension name (e.g. `jupyerlab_json`, `jupyerlab_table`).
@@ -44,11 +44,11 @@ In most cases, you will only need to edit the contents of the `component` direct
     * `static`: Compiled Javascript for both extensions
   * `component`: The React component(s)
     * `index.js`: Entry point for React component(s)
-  * `labextension`: The Jupyter Lab extension
+  * `labextension`: The JupyterLab extension
     * `src`
       * `doc.js`: Widget/widget factory used for opening files with an extension of `file_extension` defined in prompts
       * `index.css`: CSS styles for extension
-      * `plugin.js`: Entry point for the Jupyter Lab extension
+      * `plugin.js`: Entry point for the JupyterLab extension
       * `output.js`: Widget/widget factory for rendering outputs of `mime_type` defined in prompts
   * `nbextension`: The Jupyter Notebook extension
     * `src`

--- a/{{cookiecutter.extension_name}}/README.md
+++ b/{{cookiecutter.extension_name}}/README.md
@@ -13,15 +13,18 @@ A JupyterLab and Jupyter Notebook extension for rendering {{cookiecutter.mime_sh
 To render {{cookiecutter.mime_short_name}} output in IPython:
 
 ```python
-from IPython.display import JSON
-JSON({
+from {{ cookiecutter.extension_name }} import {{ cookiecutter.mime_short_name }}
+
+data = {
     'string': 'string',
     'array': [1, 2, 3],
     'bool': True,
     'object': {
         'foo': 'bar'
     }
-})
+}
+
+{{ cookiecutter.mime_short_name }}(data)
 ```
 
 To render a .{{cookiecutter.file_extension}} file as a tree, simply open it:

--- a/{{cookiecutter.extension_name}}/labextension/README.md
+++ b/{{cookiecutter.extension_name}}/labextension/README.md
@@ -4,31 +4,7 @@ A JupyterLab extension for rendering {{cookiecutter.mime_short_name}} output and
 
 ## Prerequisites
 
-<<<<<<< 0b7cfde46b61523e30d557319e0b6ea2ce3dd35f
-* JupyterLab >= 0.11
-=======
-* JupyterLab >=0.11.0
-
-## Usage
-
-To render {{cookiecutter.mime_short_name}} output in IPython:
->>>>>>> jupyterlab/master
-
-![output renderer](http://g.recordit.co/QAsC7YULcY.gif)
-
-```python
-from IPython.display import JSON
-JSON({
-    'string': 'string',
-    'array': [1, 2, 3],
-    'bool': True,
-    'object': {
-        'foo': 'bar'
-    }
-})
-```
-
-To render a .{{cookiecutter.file_extension}} file as a tree, simply open it:
+* `jupyterlab>=0.11`
 
 ![file renderer](http://g.recordit.co/cbf0xnQHKn.gif)
 

--- a/{{cookiecutter.extension_name}}/nbextension/README.md
+++ b/{{cookiecutter.extension_name}}/nbextension/README.md
@@ -4,25 +4,7 @@ A Jupyter Notebook extension for rendering {{cookiecutter.mime_short_name}} outp
 
 ## Prerequisites
 
-* Notebook >=4.3
-
-## Usage
-
-To render {{cookiecutter.mime_short_name}} output in IPython:
-
-![screenshot](http://g.recordit.co/oKTa52HTK9.gif)
-
-```python
-from IPython.display import JSON
-JSON({
-    'string': 'string',
-    'array': [1, 2, 3],
-    'bool': True,
-    'object': {
-        'foo': 'bar'
-    }
-})
-```
+* `notebook>=4.3`
 
 ## Development
 

--- a/{{cookiecutter.extension_name}}/nbextension/src/renderer.js
+++ b/{{cookiecutter.extension_name}}/nbextension/src/renderer.js
@@ -18,7 +18,7 @@ function render(data, node) {
 export function register_renderer($) {
   // Get an instance of the OutputArea object from the first CodeCellebook_
   const OutputArea = $('#notebook-container').find('.code_cell').eq(0).data('cell').output_area;
-  // A function to render output of 'application/vnd.plotly.v1+json' mime type
+  // A function to render output of '{{cookiecutter.mime_type}}' mime type
   const append_mime = function(json, md, element) {
     const type = MIME_TYPE;
     const toinsert = this.create_output_subarea(md, 'output_{{cookiecutter.mime_short_name}} rendered_html', type);
@@ -42,13 +42,13 @@ export function register_renderer($) {
 }
 
 //
-// Re-render cells with output data of 'application/vnd.plotly.v1+json' mime type
+// Re-render cells with output data of '{{cookiecutter.mime_type}}' mime type
 // 
 export function render_cells($) {
   // Get all cells in notebook
   $('#notebook-container').find('.cell').toArray().forEach(item => {
     const CodeCell = $(item).data('cell');
-    // If a cell has output data of 'application/vnd.plotly.v1+json' mime type
+    // If a cell has output data of '{{cookiecutter.mime_type}}' mime type
     if (CodeCell.output_area && CodeCell.output_area.outputs.find(output => output.data[MIME_TYPE])) {
       // Re-render the cell by executing it
       CodeCell.notebook.render_cell_output(CodeCell);

--- a/{{cookiecutter.extension_name}}/setup.py
+++ b/{{cookiecutter.extension_name}}/setup.py
@@ -29,7 +29,8 @@ setup_args = dict(
     keywords             = ['jupyter', 'jupyterlab', 'labextension', 'notebook', 'nbextension'],
     include_package_data = True,
     install_requires = [
-        'jupyterlab>=0.8.0',
+        'jupyterlab>=0.11.0',
+        'ipython>=1.0.0'
     ]
 )
 

--- a/{{cookiecutter.extension_name}}/{{cookiecutter.extension_name}}/README.md
+++ b/{{cookiecutter.extension_name}}/{{cookiecutter.extension_name}}/README.md
@@ -1,0 +1,8 @@
+# {{ cookiecutter.extension_name }}
+
+Single Python package for lab and notebook extensions
+
+## Structure
+
+* `static`: Built Javascript from `../labextension/` and `../nbextension/`
+* `__init__.py`: Exports paths for lab and notebook extensions

--- a/{{cookiecutter.extension_name}}/{{cookiecutter.extension_name}}/__init__.py
+++ b/{{cookiecutter.extension_name}}/{{cookiecutter.extension_name}}/__init__.py
@@ -1,3 +1,6 @@
+from IPython.display import display
+
+
 # Running `npm run build` will create static resources in the static
 # directory of this Python package (and create that directory if necessary).
 
@@ -15,3 +18,16 @@ def _jupyter_nbextension_paths():
         'dest': '{{ cookiecutter.extension_name }}',
         'require': '{{ cookiecutter.extension_name }}/extension'
     }]
+
+
+# A display function that can be used within a notebook. E.g.:
+#   from {{ cookiecutter.extension_name }} import {{ cookiecutter.mime_short_name }}
+#   {{ cookiecutter.mime_short_name }}(data)
+
+def {{ cookiecutter.mime_short_name }}(data):
+    bundle = {
+        '{{ cookiecutter.mime_type }}': data,
+        'application/json': data,
+        'text/plain': '<{{ cookiecutter.extension_name }}.{{ cookiecutter.mime_short_name }} object>'
+    }
+    display(bundle, raw=True)


### PR DESCRIPTION
Provides a `display` method that can be imported into a notebook:

```py
from jupyterlab_plotly import Plotly

data = [
  {'x': [1999, 2000, 2001, 2002], 'y': [10, 15, 13, 17], 'type': 'scatter'},
  {'x': [1999, 2000, 2001, 2002], 'y': [16, 5, 11, 9], 'type': 'scatter'}
]

layout = {
  'title': 'Sales Growth',
  'xaxis': { 'title': 'Year', 'showgrid': False, 'zeroline': False },
  'yaxis': { 'title': 'Percent', 'showline': False }
}

Plotly(data, layout)
```