### PR TITLE
Use ActivityMonitor to throttle users typing to update model

### DIFF
--- a/{{cookiecutter.extension_name}}/labextension/src/doc.js
+++ b/{{cookiecutter.extension_name}}/labextension/src/doc.js
@@ -7,6 +7,11 @@ import { ABCWidgetFactory } from 'jupyterlab/lib/docregistry';
 const CLASS_NAME = 'jp-DocWidget{{cookiecutter.mime_short_name}}';
 
 /**
+ * The timeout to wait for change activity to have ceased before rendering.
+ */
+const RENDER_TIMEOUT = 1000;
+
+/**
  * A widget for rendering {{cookiecutter.extension_name}} files.
  */
 export class DocWidget extends Widget {
@@ -20,6 +25,11 @@ export class DocWidget extends Widget {
     context.pathChanged.connect(() => {
       this.update();
     });
+    this._monitor = new ActivityMonitor({
+      signal: context.model.contentChanged,
+      timeout: RENDER_TIMEOUT
+    });
+    this._monitor.activityStopped.connect(this.update, this);
   }
 
   /**
@@ -28,6 +38,7 @@ export class DocWidget extends Widget {
   dispose() {
     if (!this.isDisposed) {
       this._context = null;
+      this._monitor.dispose();
       super.dispose();
     }
   }


### PR DESCRIPTION
In response to https://github.com/jupyterlab/jupyterlab_geojson/issues/24