### PR TITLE
Normalize paths in webpack config

### DIFF
--- a/{{cookiecutter.extension_name}}/labextension/build_extension.js
+++ b/{{cookiecutter.extension_name}}/labextension/build_extension.js
@@ -1,9 +1,15 @@
 var buildExtension = require('@jupyterlab/extension-builder').buildExtension;
+var path = require('path');
 
 buildExtension({
   name: '{{cookiecutter.extension_name}}',
-  entry: './src/plugin.js',
-  outputDir: '../{{cookiecutter.extension_name}}/static',
+  entry: path.join(__dirname, 'src', 'plugin.js'),
+  outputDir: path.join(
+    __dirname,
+    '..',
+    '{{cookiecutter.extension_name}}',
+    'static'
+  ),
   useDefaultLoaders: false,
   config: {
     module: {
@@ -30,11 +36,13 @@ buildExtension({
         { test: /\.json$/, loader: 'json-loader' },
         {
           test: /\.js$/,
-          exclude: /node_modules/,
+          include: [
+            path.join(__dirname, 'src')
+          ],
           loader: 'babel-loader',
           query: {
-            presets: [ 'latest' ],
-            plugins: [ 'transform-class-properties' ]
+            presets: ['latest'],
+            plugins: ['transform-class-properties']
           }
         }
       ]

--- a/{{cookiecutter.extension_name}}/nbextension/webpack.config.js
+++ b/{{cookiecutter.extension_name}}/nbextension/webpack.config.js
@@ -1,11 +1,16 @@
 var version = require('./package.json').version;
+var path = require('path');
 
-// Custom webpack loaders are generally the same for all webpack bundles, hence
-// stored in a separate local variable.
+/**
+ * Custom webpack loaders are generally the same for all webpack bundles, hence
+ * stored in a separate local variable.
+ */
 var loaders = [
   {
     test: /\.js$/,
-    exclude: /node_modules/,
+    include: [
+      path.join(__dirname, 'src')
+    ],
     loader: 'babel-loader',
     query: { presets: [ 'latest' ] }
   },
@@ -33,67 +38,78 @@ var loaders = [
 ];
 
 module.exports = [
+  /**
+   * Notebook extension
+   * 
+   * This bundle only contains the part of the JavaScript that is run on
+   * load of the notebook. This section generally only performs
+   * some configuration for requirejs, and provides the legacy
+   * "load_ipython_extension" function which is required for any notebook
+   * extension.
+   */
   {
-    // Notebook extension
-    //
-    // This bundle only contains the part of the JavaScript that is run on
-    // load of the notebook. This section generally only performs
-    // some configuration for requirejs, and provides the legacy
-    // "load_ipython_extension" function which is required for any notebook
-    // extension.
-    //
-    entry: './src/extension.js',
+    entry: path.join(__dirname, 'src', 'extension.js'),
     output: {
       filename: 'extension.js',
-      path: '../{{cookiecutter.extension_name}}/static',
+      path: path.join(
+        __dirname,
+        '..',
+        '{{cookiecutter.extension_name}}',
+        'static'
+      ),
       libraryTarget: 'amd'
     },
     devtool: 'source-map',
     module: { loaders },
-    externals: [
-      'nbextensions/{{cookiecutter.extension_name}}/index',
-      'base/js/namespace'
-    ]
+    externals: ['nbextensions/{{cookiecutter.extension_name}}/index', 'jquery']
   },
+  /**
+   * Bundle for the notebook containing the custom widget views and models
+   * 
+   * This bundle contains the implementation for the custom widget views and
+   * custom widget.
+   * 
+   * It must be an amd module
+   */
   {
-    // Bundle for the notebook containing the custom widget views and models
-    //
-    // This bundle contains the implementation for the custom widget views and
-    // custom widget.
-    // It must be an amd module
-    //
-    entry: './src/index.js',
+    entry: path.join(__dirname, 'src', 'index.js'),
     output: {
       filename: 'index.js',
-      path: '../{{cookiecutter.extension_name}}/static',
+      path: path.join(
+        __dirname,
+        '..',
+        '{{cookiecutter.extension_name}}',
+        'static'
+      ),
       libraryTarget: 'amd'
     },
     devtool: 'source-map',
     module: { loaders }
   },
+  /**
+   * Embeddable {{cookiecutter.extension_name}} bundle
+   * 
+   * This bundle is generally almost identical to the notebook bundle
+   * containing the custom widget views and models.
+   * 
+   * The only difference is in the configuration of the webpack public path
+   * for the static assets.
+   * 
+   * It will be automatically distributed by unpkg to work with the static
+   * widget embedder.
+   * 
+   * The target bundle is always `lib/index.js`, which is the path required
+   * by the custom widget embedder.
+   */
   {
-    // Embeddable {{cookiecutter.extension_name}} bundle
-    //
-    // This bundle is generally almost identical to the notebook bundle
-    // containing the custom widget views and models.
-    //
-    // The only difference is in the configuration of the webpack public path
-    // for the static assets.
-    //
-    // It will be automatically distributed by unpkg to work with the static
-    // widget embedder.
-    //
-    // The target bundle is always `lib/index.js`, which is the path required
-    // by the custom widget embedder.
-    //
-    entry: './src/embed.js',
+    entry: path.join(__dirname, 'src', 'embed.js'),
     output: {
       filename: 'index.js',
-      path: './embed/',
+      path: path.join(__dirname, 'embed'),
       libraryTarget: 'amd',
-      publicPath: 'https://unpkg.com/{{cookiecutter.extension_name}}@' +
-        version +
-        '/lib/'
+      publicPath: (
+        'https://unpkg.com/{{cookiecutter.extension_name}}@' + version + '/lib/'
+      )
     },
     devtool: 'source-map',
     module: { loaders }


### PR DESCRIPTION
Fixes an issue that affected webpack compilation on Windows: https://github.com/gnestor/jupyterlab_plotly/issues/9