### PR TITLE
Output string representation of data in `text/plain`

### DIFF
--- a/{{cookiecutter.extension_name}}/{{cookiecutter.extension_name}}/__init__.py
+++ b/{{cookiecutter.extension_name}}/{{cookiecutter.extension_name}}/__init__.py
@@ -40,6 +40,6 @@ class {{cookiecutter.mime_short_name}}(JSON):
     def _ipython_display_(self):
         bundle = {
             '{{cookiecutter.mime_type}}': self.data,
-            'text/plain': '<{{cookiecutter.extension_name}}.{{cookiecutter.mime_short_name}} object>'
+            'text/plain': json.dumps(self.data, indent=4)
         }
         display(bundle, raw=True)


### PR DESCRIPTION
@ellisonbg What are your thoughts about returning a text representation of the data (`json.dumps(self.data, indent=4)`) vs. `<{{cookiecutter.extension_name}}.{{cookiecutter.mime_short_name}} object>`?