### PR TITLE
Remove trailing comma in JSON

### DIFF
--- a/{{cookiecutter.extension_name}}/labextension/package.json
+++ b/{{cookiecutter.extension_name}}/labextension/package.json
@@ -25,7 +25,7 @@
     "@jupyterlab/docregistry": "^0.1.3",
     "@jupyterlab/rendermime": "^0.1.3",
     "@phosphor/algorithm": "^0.1.1",
-    "@phosphor/widgets": "^0.3.0",
+    "@phosphor/widgets": "^0.3.0"
   },
   "devDependencies": {
     "@jupyterlab/extension-builder": "^0.10.0",


### PR DESCRIPTION
This trailing comma causes errors when building a custom extension. 